### PR TITLE
Only put things in deltaUsesMap if uses > 0

### DIFF
--- a/src/main/java/com/shimmermare/inviteroles/InviteTracker.java
+++ b/src/main/java/com/shimmermare/inviteroles/InviteTracker.java
@@ -88,8 +88,10 @@ public final class InviteTracker
             {
                 LOGGER.error("Server {} invite {} uses delta is negative ({}). This is shouldn't be possible.", guild.getIdLong(), invite.getCode(), deltaUses);
                 continue;
+            } 
+            if (deltaUses > 0) {
+                deltaUsesMap.put(invite.getCode(), deltaUses);
             }
-            deltaUsesMap.put(invite.getCode(), deltaUses);
         }
         deltaUses = Collections.unmodifiableMap(deltaUsesMap);
     }


### PR DESCRIPTION
There's a bug where having multiple active invites makes the bot always complain about 2 people joining at the same time.

That's because the code checks `deltaUsesMap.size()`, and if that's greater than 1, it throws the 2 people joined at the same time error. But right now the delta map is full of unused invites. 