### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM maven:3-openjdk-16-slim AS maven
+
+COPY ./pom.xml ./pom.xml
+COPY ./src ./src
+
+RUN mvn package
+
+FROM openjdk:16-alpine
+
+COPY --from=maven target/InviteRoles-*-jar-with-dependencies.jar /java.jar
+COPY ./entry.sh /entry.sh
+
+CMD ["/entry.sh"]

--- a/entry.sh
+++ b/entry.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+java -jar /java.jar --token="${DISCORD_TOKEN}" --db="/database/db.sqlite"

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdaVersion>4.0.0_47</jdaVersion>
+        <jdaVersion>4.2.0_168</jdaVersion>
         <brigadierVersion>1.0.17</brigadierVersion>
         <joptVersion>5.0.4</joptVersion>
         <logbackVersion>1.2.3</logbackVersion>

--- a/src/main/java/com/shimmermare/inviteroles/InviteRoles.java
+++ b/src/main/java/com/shimmermare/inviteroles/InviteRoles.java
@@ -99,7 +99,7 @@ public class InviteRoles
         commandDispatcher = new CommandDispatcher<>();
         Command.register(commandDispatcher);
 
-        JDABuilder jdaBuilder = new JDABuilder(token);
+        JDABuilder jdaBuilder = JDABuilder.createDefault(token);
 
         try
         {

--- a/src/main/java/com/shimmermare/inviteroles/InviteRoles.java
+++ b/src/main/java/com/shimmermare/inviteroles/InviteRoles.java
@@ -110,7 +110,7 @@ public class InviteRoles
         catch (LoginException e)
         {
             LOGGER.error("Unable to login to Discord", e);
-            return;
+            System.exit(-1);
         }
 
         try
@@ -120,7 +120,7 @@ public class InviteRoles
         catch (InterruptedException e)
         {
             LOGGER.error("Failed to await JDA ready", e);
-            return;
+            System.exit(-1);
         }
 
         User selfUser = jda.getSelfUser();


### PR DESCRIPTION
Based of Tag `v1.0.1` this implements an alpine based Docker image using OpenJDK 16.

Sadly due to java being excessively bloated by nature the container is still 335MB in size. (321MB for the JDK Alpine image)